### PR TITLE
Test TM2 and TP5 on M8U

### DIFF
--- a/ublox_gps/config/m8u_rover.yaml
+++ b/ublox_gps/config/m8u_rover.yaml
@@ -43,3 +43,9 @@ inf:
 # Enable u-blox message publishers
 publish:
   all: true
+  esf:
+    raw: true
+  tim:
+    tm2: true
+  nav:
+    clock: true

--- a/ublox_gps/config/m8u_rover1.yaml
+++ b/ublox_gps/config/m8u_rover1.yaml
@@ -1,0 +1,51 @@
+# Configuration Settings for C94-M8P device
+
+debug: 3                    # Range 0-4 (0 means no debug statements will print)
+
+save:
+  mask: 3103                # Save I/O, Message, INF Message, Nav, Receiver 
+                            # Manager, Antenna, and Logging Configuration
+  device: 4                 # Save to EEPROM
+
+device: /dev/ttyACM1
+frame_id: m8u 
+rate: 1                     # in Hz
+nav_rate: 1                 # [# of measurement cycles], recommended 1 Hz, may 
+
+hnr_rate: 10                # be either 5 Hz (Dual constellation) or 
+                            # 8 Hz (GPS only)
+
+tp_active: 1
+
+dynamic_model: 0    # Airborne < 2G, 2D fix not supported (3D only), 
+                            # Max Alt: 50km
+                            # Max Horizontal Velocity: 250 m/s, 
+                            # Max Vertical Velocity: 100 m/s
+fix_mode: 3 
+#enable_ppp: true           # Not supported by C94-M8P
+#dr_limit: 1
+useAdr: true 
+
+uart1:
+  baudrate: 115200           # C94-M8P specific
+  in: 7
+  out: 7
+gnss:
+  glonass: true             # Supported by C94-M8P
+  beidou: false             # Supported by C94-M8P
+  qzss: false               # Supported by C94-M8P
+
+dgnss_mode: 3               # Fixed mode
+
+inf: 
+  all: true                   # Whether to display all INF messages in console
+
+# Enable u-blox message publishers
+publish:
+  all: true
+  esf:
+    raw: true
+  tim:
+    tm2: true
+  nav:
+    clock: true

--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -637,8 +637,15 @@ class UbloxNode : public virtual ComponentInterface {
   ublox_msgs::CfgCFG load_;
   //! Parameters to save to non-volatile memory after configuration
   ublox_msgs::CfgCFG save_;
-  //! rate for TIM-TM2
-  uint8_t tim_rate_;
+
+ protected:
+  /**
+   * @brief
+   * @details Publish recieved TimTM2 messages if enabled
+   */
+  void callbackTimTM2(const ublox_msgs::TimTM2 &m);
+
+  sensor_msgs::TimeReference t_ref_;
 };
 
 /**
@@ -1312,15 +1319,6 @@ class TimProduct: public virtual ComponentInterface {
    * @todo Currently unimplemented.
    */
   void initializeRosDiagnostics();
-
- protected:  
-  /**
-   * @brief 
-   * @details Publish recieved TimTM2 messages if enabled
-   */
-  void callbackTimTM2(const ublox_msgs::TimTM2 &m);
- 
-  sensor_msgs::TimeReference t_ref_;
 };
 
 }

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -116,7 +116,7 @@ void Gps::initializeSerial(std::string port, unsigned int baudrate,
   }
 
   ROS_INFO("U-Blox: Opened serial port %s", port.c_str());
-    
+
   if(BOOST_VERSION < 106600)
   {
     // NOTE(Kartik): Set serial port to "raw" mode. This is done in Boost but
@@ -282,7 +282,7 @@ bool Gps::configGnss(CfgGNSS gnss,
   ROS_WARN("GNSS re-configured, cold resetting device.");
   if (!configReset(CfgRST::NAV_BBR_COLD_START, CfgRST::RESET_MODE_GNSS))
     return false;
-  
+
   ROS_DEBUG("Waiting 1 second for device to reset...");
   ros::Duration(1.0).sleep();
   // Reset the I/O
@@ -521,10 +521,10 @@ bool Gps::setUseAdr(bool enable) {
 
 bool Gps::setHnrPVT(uint8_t rate) {
   ROS_DEBUG("Setting HNR-PVT to %u", rate);
-  
+
   ublox_msgs::CfgHNR msg;
   msg.highNavRate = rate;
-  
+
   return configure(msg);
 }
 
@@ -532,32 +532,21 @@ bool Gps::setTimePulse(uint8_t tp_ch, bool enable) {
   ROS_DEBUG("%s Time Pulse %u", (enable ? "Enabling" : "Disabling"), tp_ch);
 
   ublox_msgs::CfgTP5 msg;
- 
+
   msg.tpIdx = tp_ch;
-  msg.version = 1; 
+  msg.version = 1;
   msg.antCableDelay = 0;
   msg.rfGroupDelay = 0;
   msg.freqPeriod = 10;
   msg.freqPeriodLock = 10;
-  msg.pulseLenRatio = 5;
-  msg.pulseLenRatioLock = 5;
+  msg.pulseLenRatio = 50;
+  msg.pulseLenRatioLock = 50;
   msg.userConfigDelay = 0;
- 
-  ROS_DEBUG("msg flags are: %u", msg.flags);
-  std::bitset<32> new_flags;
-  
-  new_flags[0] = 1;
-  new_flags[1] = 1;
-  new_flags[2] = 1;
-  new_flags[3] = 1;
-  new_flags[4] = 1;
-  new_flags[5] = 1;
-  new_flags[7] = 1;
-  new_flags[11] = 1;
-  
-  msg.flags = new_flags.to_ulong();
- 
-  ROS_DEBUG("msg flags set to: %u", msg.flags);
+
+  msg.flags =
+    CfgTP5::FLAGS_ACTIVE | CfgTP5::FLAGS_LOCKED_OTHER_SET |
+    CfgTP5::FLAGS_IS_FREQ | CfgTP5::FLAGS_GRID_UTC_GNSS_GPS;
+  ROS_DEBUG("msg flags set to: %#x", msg.flags);
 
   return configure(msg);
 }
@@ -609,7 +598,7 @@ bool Gps::setTimtm2(uint8_t rate) {
   ublox_msgs::CfgMSG msg;
   msg.msgClass = ublox_msgs::TimTM2::CLASS_ID;
   msg.msgID = ublox_msgs::TimTM2::MESSAGE_ID;
-  msg.rate  = rate; 
+  msg.rate  = rate;
   return configure(msg);
 }
 }  // namespace ublox_gps

--- a/ublox_msgs/msg/CfgTP5.msg
+++ b/ublox_msgs/msg/CfgTP5.msg
@@ -1,25 +1,67 @@
 # UBX-CFG-TP5 (0x06 0x31)
-# USB Configuration
-#
+# Time Pulse Configuration
+# For Ublox 8, version 16 through 22
 
 uint8 CLASS_ID = 6
 uint8 MESSAGE_ID = 49 
 
-uint8 tpIdx                # Time Pulse Selection (0 = TP, 1 = TP2)                     
+uint8 tpIdx              # Time Pulse Selection (0 = TIMEPULSE, 1 = TIMEPULSE2)
 
-uint8 version              # Message version (0x01) for this version) 
+uint8 version            # Message version (0x01 for this version)
 
-uint8[2] reserved1          # Reserved
+uint8[2] reserved1
 
 int16 antCableDelay
 int16 rfGroupDelay
 
-uint32 freqPeriod
-uint32 freqPeriodLock
-uint32 pulseLenRatio
-uint32 pulseLenRatioLock
+uint32 freqPeriod        # Frequency or period time, depending on bit isFreq
+uint32 freqPeriodLock    # Frequency or period time when locked to GNSS time,
+                         # only used if lockedOtherSet is set
+uint32 pulseLenRatio     # Pulse length or duty cycle, depending on isLength
+uint32 pulseLenRatioLock # Pulse length or duty cycle when locked to GNSS time,
+                         # only used if lockedOtherSet is set
 
 int32 userConfigDelay
 
 uint32 flags
+uint32 FLAGS_ACTIVE          = 1 # if set enable time pulse;
+  # if pin assigned to another function, other function takes precedence
+uint32 FLAGS_LOCK_GNSS_FREQ  = 2 # if set synchronize time pulse to GPS
+  # as soon as GPS time is valid, otherwise use local clock
+uint32 FLAGS_LOCKED_OTHER_SET= 4 # if 0 then freqPeriod & pulseLenRatio used
+  # if set use freqPeriodLock & pulseLenRatioLock as soon as GPS time is valid
+  #   use freqPeriod and pulseLenRatio if GPS time is invalid,
 
+uint32 FLAGS_IS_FREQ     = 8 # if set freqPeriodLock and freqPeriod
+  # interpreted as frequency, otherwise interpreted as period
+uint32 FLAGS_IS_LENGTH   =16 # if set pulseLenRatioLock and pulseLenRatio
+  # interpreted as pulse length, otherwise interpreted as duty cycle
+uint32 FLAGS_ALIGN_TO_TOW=32 # align pulse to top of second
+  # (period time must be integer fraction of 1s)
+uint32 FLAGS_POLARITY    =64 # pulse polarity at top of sec, 0=falling 1=rising
+
+
+# Timegrid to use:
+  # This flag is only relevant if lockGnssFreq and alignToTow are set.
+uint32 FLAGS_GRID_UTC_GNSS_MASK   =1920 # 4 bits 0xf<<7=0x0780
+uint32 FLAGS_GRID_UTC_GNSS_UTC    =   0 # timegrid to use: 0=UTC
+uint32 FLAGS_GRID_UTC_GNSS_GPS    = 128 # timegrid to use: 1=GPS
+uint32 FLAGS_GRID_UTC_GNSS_GLONASS= 256 # timegrid to use: 2=GCLONAS
+  #TODO "3" and "4" could instead mean bit 3 512 and bit 4 1024, not 384 & 512:
+uint32 FLAGS_GRID_UTC_GNSS_BEIDOU = 384 # timegrid to use: 3=BeiDou
+uint32 FLAGS_GRID_UTC_GNSS_GALILEO= 512 # timegrid to use: 4=Galileo
+
+
+# Sync Manager lock mode:
+  # This field is only relevant for the FTS product variant.
+  # This field is only relevant if the flag lockedOtherSet is set.
+uint32 FLAGS_SYNC_MODE_MASK=14336 # 3 bits 0x7<<11=0x2800
+
+  # 0: switch to freqPeriodLock and pulseLenRatioLock as soon as Sync Manager
+  # has an accurate time,
+uint32 FLAGS_SYNC_MODE_0=0 # 0: never switch back to freqPeriod & pulseLenRatio
+
+  # 1: switch to freqPeriodLock and pulseLenRatioLock as soon as Sync Manager
+  # has an accurate time,
+uint32 FLAGS_SYNC_MODE_1=2048 # 1: switch back to freqPeriod & pulseLenRatio
+  # as soon as time gets inaccurate


### PR DESCRIPTION
Reversed the change where I made UDR devices also TIM capable, instead moved TM2 support to the generic UbloxNode (it is supported in firmware 6, 7 and 8, and in January 2016 Ublox support said TM2 was supported by all current receivers).  Completed the TP5 flags according to the documentation.  These changes run without getting a NACK but I have not been able to prove the functionality with my current hardware.